### PR TITLE
Update Labeler documentation with async/await syntax and database configuration

### DIFF
--- a/src/content/guides/labeler/introduction/getting-started.mdx
+++ b/src/content/guides/labeler/introduction/getting-started.mdx
@@ -72,6 +72,8 @@ The `LabelerServer` class takes an object argument with the following properties
 - `signingKey`: The signing key used to sign labels. This should be the same key you received when setting up the labeler, if you used the setup CLI command.
 - `auth` (optional): A function that takes a DID and returns a boolean indicating whether the DID is authorized to emit labels. If not provided, only the labeler account can emit labels.
 - `dbPath` (optional): The path to the database file. Defaults to `./labels.db`.
+- `dbUrl` (optional): The URL of the database. Use this instead of `dbPath` if you want to use a remote libSQL database.
+- `dbAuthToken` (optional): The authentication token for the database. Required if `dbUrl` is provided.
 
 After initializing the server, call the `start` method with the port number to listen on and a callback that will be called when the server starts. If an error occurs, the callback will be called with the error.
 
@@ -82,7 +84,7 @@ If all has gone well, you're ready to start labeling content!
 ```ts twoslash
 declare const server: import("@skyware/labeler").LabelerServer;
 // ---cut---
-server.createLabel({
+await server.createLabel({
     // If you're labeling a record, this should be an at:// URI pointing to the record.
     // If you're labeling an account, this should be the account's DID.
     uri: "did:plc:427uaandx74txvzakxthrjwu",
@@ -96,7 +98,7 @@ To undo a label, emit the same label with the `neg` property set to `true` to `n
 ```ts twoslash
 declare const server: import("@skyware/labeler").LabelerServer;
 // ---cut---
-server.createLabel({
+await server.createLabel({
     uri: "did:plc:427uaandx74txvzakxthrjwu",
     val: "cool-cat",
     neg: true

--- a/src/content/guides/labeler/introduction/getting-started.mdx
+++ b/src/content/guides/labeler/introduction/getting-started.mdx
@@ -73,7 +73,7 @@ The `LabelerServer` class takes an object argument with the following properties
 - `auth` (optional): A function that takes a DID and returns a boolean indicating whether the DID is authorized to emit labels. If not provided, only the labeler account can emit labels.
 - `dbPath` (optional): The path to the database file. Defaults to `./labels.db`.
 - `dbUrl` (optional): The URL of the database. Use this instead of `dbPath` if you want to use a remote libSQL database.
-- `dbAuthToken` (optional): The authentication token for the database. Required if `dbUrl` is provided.
+- `dbToken` (optional): The authentication token for the database. Required if a remote `dbUrl` is provided.
 
 After initializing the server, call the `start` method with the port number to listen on and a callback that will be called when the server starts. If an error occurs, the callback will be called with the error.
 


### PR DESCRIPTION
Updating the Labeler documentation to match the changes introduced in https://github.com/skyware-js/labeler/pull/4

1. Add documentation for new database configuration options:
   - `dbUrl`: Optional URL for connecting to a remote libSQL database
     - Specifically calls out libSQL instead of SQLite since remote connections require the libSQL protocol/client
   - `dbAuthToken`: Optional authentication token required when using `dbUrl`

2. Replaced `server.createLabel({...})` with `await server.createLabel({...})` to reflect the methods becoming asynchronous