### PR TITLE
Add a note about nuking labeler state

### DIFF
--- a/src/content/guides/labeler/introduction/getting-started.mdx
+++ b/src/content/guides/labeler/introduction/getting-started.mdx
@@ -12,16 +12,15 @@ Before you start, you will need:
 - A domain
 - An SSL certificate for your domain
 
-## Running in dev env
+## Dev Note
 
-Bluesky consumes labels via `com.atproto.label.subscribeLabels` method and remembers what labels it has seen from your labeler account. This means that labels you create while developing your labeler permanently affect how Bluesky sees it. Each label creation or retraction increments the cursor of your label stream and there's no (good) way to reset it on Bluesky's side, so to avoid issues later on it must also not reset on your side too.
+Before you start, there's a few things to note. When you emit a label, that label is permanently stored by Bluesky and other [AppViews](/guides/labeler/glossary#appview). Deleting your database will not reset that. It will, however, make it very difficult for you to start emitting labels again, as you will be starting again from label 0, which AppViews think they've already seen.
 
-Particular things to **avoid** doing:
+It's recommended that you **should** use a separate account for development until you know your labeler is working, at which point you can create a new account and delete the database.
 
-- Deleting the DB file to start from scratch
-- Deploying your labeler without copying the DB file from development environment
+You **should** also only have a single database per labeler account. This means that if you're switching between development and production with the same account, make sure to copy the database file between machines.
 
-It might be a good idea to use a separate account for development too. But even then, avoid deleting the DB, otherwise your dev account won't function properly.
+You should **not** delete your database file unless you will not be using that account as a labeler anymore, in which case you should run `npx @skyware/labeler clear` afterwards to return it to a regular account.
 
 ## Setup
 

--- a/src/content/guides/labeler/introduction/getting-started.mdx
+++ b/src/content/guides/labeler/introduction/getting-started.mdx
@@ -12,6 +12,17 @@ Before you start, you will need:
 - A domain
 - An SSL certificate for your domain
 
+## Running in dev env
+
+Bluesky consumes labels via `com.atproto.label.subscribeLabels` method and remembers what labels it has seen from your labeler account. This means that labels you create while developing your labeler permanently affect how Bluesky sees it. Each label creation or retraction increments the cursor of your label stream and there's no (good) way to reset it on Bluesky's side, so to avoid issues later on it must also not reset on your side too.
+
+Particular things to **avoid** doing:
+
+- Deleting the DB file to start from scratch
+- Deploying your labeler without copying the DB file from development environment
+
+It might be a good idea to use a separate account for development too. But even then, avoid deleting the DB, otherwise your dev account won't function properly.
+
 ## Setup
 
 If you already have a labeler set up, via Ozone or otherwise, you can skip this step.


### PR DESCRIPTION
Sometimes people don't realize that AppView keeps track of the cursor and think that deleting the DB in dev is fine, but it causes them issues later on.